### PR TITLE
Fixup grep for checking if this is the first run

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -28,7 +28,7 @@ class dotfiles (
   }
   -> exec { 'dotfile upgrade':
     command => "${bin} install",
-    onlyif  => "${bin} super_update 2>&1 | grep -e '^From' -e '^Cloning'"
+    onlyif  => "${bin} super_update 2>&1 | grep -q 'Cloning into'"
   }
   ~> exec { 'run dotfile post_upgrade':
     command     => "${homedir}/.meta/dotfile_post_upgrade",


### PR DESCRIPTION
This switches up the grep to match what https://github.com/akerl/.../ currently is outputing on the first run with https://github.com/jaredledvina/dotfiles/blob/master/.dotdotdot.conf

```
Jareds-MacBook-Pro:... ghavil$ rm -rf src/dotfiles/
Jareds-MacBook-Pro:... ghavil$ /Users/ghavil/.../... super_update
Updating your `...` system and dot files... in parallel!
> (cd ~/... && git clean -f && git reset --hard HEAD)
> git clone --depth 1 --recursive git://github.com/jaredledvina/dotfiles ~/.../src/dotfiles
Cloning into '/Users/ghavil/.../src/dotfiles'...
HEAD is now at 63dfcff update readme notes
> (cd ~/... && git pull --ff-only && git submodule update --init)
remote: Counting objects: 6, done.
remote: Compressing objects: 100% (5/5), done.
remote: Total 6 (delta 0), reused 0 (delta 0), pack-reused 0
Receiving objects: 100% (6/6), done.
Already up to date.
```

Current behavior:
```
Jareds-MacBook-Pro:... ghavil$ rm -rf src/dotfiles/
Jareds-MacBook-Pro:... ghavil$ /Users/ghavil/.../... super_update 2>&1 | grep -e '^From' -e '^Cloning'
Jareds-MacBook-Pro:... ghavil$ echo $?
1
```

New bits;
```
Jareds-MacBook-Pro:... ghavil$ rm -rf src/dotfiles/
Jareds-MacBook-Pro:... ghavil$ /Users/ghavil/.../... super_update 2>&1 | grep -q 'Cloning into'; echo $?
0
```